### PR TITLE
feat: add ARM64 support and robust extraction logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ A shell-based installation and lifecycle management utility for running Antigrav
 
 ## Technical Features
 
-*   **🔒 Isolated Fetch & Extract:** Downloads official Linux x64 tarballs from Google Cloud Storage to secure temporary directories before validation and extraction, preventing raw-stream security vulnerabilities.
+*   **🔒 Isolated Fetch & Extract:** Downloads official Linux tarballs from Google Cloud Storage to secure temporary directories before validation and extraction, preventing raw-stream security vulnerabilities.
 *   **⚙️ Native Wayland & GPU Optimization:** Automatically injects native Chromium Wayland ozone parameters (`--ozone-platform-hint=wayland` and `--enable-features=WaylandWindowDecorations,CanvasOopRasterization`) to bypass XWayland completely, eliminating graphics lag and text blurriness.
 *   **🛡️ SELinux Restorations:** Invokes `restorecon` recursively across installed application paths to maintain strict Fedora security policies.
 *   **👥 Dual Install Scope Support:** Operates under system-wide paths (e.g. `/opt`, `/usr/local/bin`) or completely passwordless user-space scopes (e.g. `~/.local/share`, `~/.local/bin`).
+*   **💻 Architecture Support:** Natively supports both **x86_64** and **aarch64** (ARM64) architectures.
 *   **🧹 Conflicting Entries Cleanup:** Sweeps and deletes duplicate desktop launcher conflicts (like `antigravity-2.desktop`) and forces standard GNOME cache indexes to update immediately.
 *   **🧪 Verification Dry-Runs:** Supports environment testing and download verification via the `--dry-run` flag without making any filesystem modifications.
 
@@ -33,86 +34,8 @@ curl -sSL "https://raw.githubusercontent.com/jssroberto/antigravity-2-fedora-ins
 ## Usage & Installation Scopes
 
 ### 1. System-Wide Installation (Default)
-Extracts the application folder to `/opt/Antigravity-x64/`, symlinks the execution path to `/usr/local/bin/antigravity`, and registers system-wide launcher menus.
+Extracts the application folder to `/opt/Antigravity-Linux/`, symlinks the execution path to `/usr/local/bin/antigravity`, and registers system-wide launcher menus.
 ```bash
 ./install.sh
 ```
-*(Requires administrative privileges; you will be prompted for your `sudo` password).*
-
-### 2. User-Local Installation (Passwordless)
-Installs completely under your home directory without requiring elevated privileges.
-```bash
-./install.sh --user
-```
-*   **Application Directory:** `~/.local/share/Antigravity-x64/`
-*   **Executable Link:** `~/.local/bin/antigravity`
-*   **Desktop Shortcut:** `~/.local/share/applications/antigravity.desktop`
-
-### 3. Dry-Run Verification
-Validates the local environment, checks utility prerequisites, and verifies download mirrors without writing any files to your disk:
-```bash
-./install.sh --dry-run
-```
-
-### 4. Custom Archive Override
-To install a specific version or override the GCS mirror URL:
-```bash
-./install.sh --url "https://custom-mirror.com/path/to/Antigravity.tar.gz"
-```
-
----
-
-## Command-Line Arguments
-
-| Flag | Argument | Description |
-| :--- | :--- | :--- |
-| `--user` | *None* | Switch scope to user space (`~/.local`). Runs completely without root (`sudo`). |
-| `--url` | `<url>` | Override the default Google Cloud Storage download link. |
-| `--dry-run` | *None* | Perform validation checks and download package without writing system modifications. |
-| `-h, --help` | *None* | Print script usage guide and exit. |
-
----
-
-## Dual-Version Launcher Integration (Workaround)
-
-If you maintain both the Antigravity IDE (v1.x) and the new standalone application (v2.0) on the same machine, this installation is designed to support both working side-by-side, with dedicated launcher shortcuts:
-
-1. **Antigravity IDE (v1.x):** Registered as **"Antigravity"** (executes `/usr/share/antigravity/antigravity`).
-2. **Antigravity 2.0 (Standalone v2.0):** Registered as **"Antigravity 2.0"** (executes `/opt/Antigravity-x64/antigravity` or local space).
-
-### Wayland Dock Grouping Limitation
-Under native Wayland sessions, both the v1.x IDE and the v2.0 standalone executables identify using the exact same Wayland `app_id` (`"antigravity"`).
-* **Workaround Mechanism:** Since GNOME Shell maps Wayland windows to launchers strictly by their `.desktop` file name matching their `app_id`, active windows for both versions will group under the primary `antigravity.desktop` (Antigravity 2.0) launcher.
-* **Visual Behavior:** When you launch either version (the v1.x IDE or the new 2.0 editor), the running window's active status dot indicator will illuminate under the **Antigravity 2.0** icon in your GNOME dock. This is an upstream limitation of the shared `app_id`, but it allows both environments to work perfectly side-by-side without generating duplicate or conflicting icons in your application grid or dock.
-
----
-
-## Troubleshooting
-
-### Wayland & Graphics Performance
-Fedora Workstation defaults to Wayland. If you experience performance scaling glitches or cursor lag under specific GPU architectures:
-1. Open the local desktop entry shortcut file:
-   * System-wide: `/usr/share/applications/antigravity.desktop`
-   * User-local: `~/.local/share/applications/antigravity.desktop`
-2. Verify the native Wayland flags in the `Exec` line:
-   ```ini
-   Exec=/usr/local/bin/antigravity --ozone-platform-hint=wayland --enable-features=WaylandWindowDecorations,CanvasOopRasterization --enable-gpu-rasterization --enable-zero-copy %F
-   ```
-3. Ensure that your workstation has appropriate hardware acceleration drivers configured (`mesa-dri-drivers` or proprietary GPU drivers with native Wayland support enabled).
-
----
-
-## Uninstallation
-
-To cleanly wipe all binaries, symlinks, desktop entries, and configuration caches for both scopes:
-
-```bash
-chmod +x uninstall.sh
-./uninstall.sh
-```
-
----
-
-## License
-
-This project is open-source and available under the [MIT License](LICENSE).
+*(Requires administrative privileges; you will be prompted for your `sudo` password).*\n\n### 2. User-Local Installation (Passwordless)\nInstalls completely under your home directory without requiring elevated privileges.\n```bash\n./install.sh --user\n```\n*   **Application Directory:** `~/.local/share/Antigravity-Linux/`\n*   **Executable Link:** `~/.local/bin/antigravity`\n*   **Desktop Shortcut:** `~/.local/share/applications/antigravity.desktop`\n\n### 3. Dry-Run Verification\nValidates the local environment, checks utility prerequisites, and verifies download mirrors without writing any files to your disk:\n```bash\n./install.sh --dry-run\n```\n\n### 4. Custom Archive Override\nTo install a specific version or override the GCS mirror URL:\n```bash\n./install.sh --url \"https://custom-mirror.com/path/to/Antigravity.tar.gz\"\n```\n\n---\n\n## Command-Line Arguments\n\n| Flag | Argument | Description |\n| :--- | :--- | :--- |\n| `--user` | *None* | Switch scope to user space (`~/.local`). Runs completely without root (`sudo`). |\n| `--url` | `<url>` | Override the default Google Cloud Storage download link. |\n| `--dry-run` | *None* | Perform validation checks and download package without writing system modifications. |\n| `-h, --help` | *None* | Print script usage guide and exit. |\n\n---\n\n## Dual-Version Launcher Integration (Workaround)\n\nIf you maintain both the Antigravity IDE (v1.x) and the new standalone application (v2.0) on the same machine, this installation is designed to support both working side-by-side, with dedicated launcher shortcuts:\n\n1. **Antigravity IDE (v1.x):** Registered as **\"Antigravity\"** (executes `/usr/share/antigravity/antigravity`).\n2. **Antigravity 2.0 (Standalone v2.0):** Registered as **\"Antigravity 2.0\"** (executes `/opt/Antigravity-Linux/antigravity\" or local space).`

--- a/install.sh
+++ b/install.sh
@@ -79,14 +79,14 @@ echo -e "${BLUE}Targeting scope: ${BOLD}${INSTALL_SCOPE}${NC}"
 # Define paths based on install scope
 if [[ "$INSTALL_SCOPE" == "system" ]]; then
     TARGET_PARENT_DIR="/opt"
-    TARGET_APP_DIR="/opt/Antigravity-x64"
+    TARGET_APP_DIR="/opt/Antigravity-Linux"
     TARGET_BIN_PATH="/usr/local/bin/antigravity"
     DESKTOP_ENTRY_DIR="/usr/share/applications"
     DESKTOP_ENTRY_PATH="$DESKTOP_ENTRY_DIR/antigravity.desktop"
     ICON_LOOKUP_NAME="antigravity"
 else
     TARGET_PARENT_DIR="$HOME/.local/share"
-    TARGET_APP_DIR="$HOME/.local/share/Antigravity-x64"
+    TARGET_APP_DIR="$HOME/.local/share/Antigravity-Linux"
     TARGET_BIN_PATH="$HOME/.local/bin/antigravity"
     DESKTOP_ENTRY_DIR="$HOME/.local/share/applications"
     DESKTOP_ENTRY_PATH="$DESKTOP_ENTRY_DIR/antigravity.desktop"
@@ -95,8 +95,8 @@ fi
 
 # Pre-flight check: CPU Architecture
 ARCH=$(uname -m)
-if [[ "$ARCH" != "x86_64" ]]; then
-    echo -e "${RED}Error: Antigravity Linux build is strictly x86_64. Detected: ${ARCH}${NC}" >&2
+if [[ "$ARCH" != "x86_64" && "$ARCH" != "aarch64" ]]; then
+    echo -e "${RED}Error: Antigravity Linux build is strictly x86_64 or aarch64. Detected: ${ARCH}${NC}" >&2
     exit 1
 fi
 
@@ -164,12 +164,29 @@ fi
 # Ensure parent directory exists
 escalate_cmd mkdir -p "$TARGET_PARENT_DIR"
 
-# Extract archive directly into destination
-escalate_cmd tar -xzf "$TEMP_ARCHIVE" -C "$TARGET_PARENT_DIR"
+# Extract archive to a temporary location to detect the internal folder name
+EXTRACT_TEMP="$TEMP_DIR/extract_temp"
+mkdir -p "$EXTRACT_TEMP"
+tar -xzf "$TEMP_ARCHIVE" -C "$EXTRACT_TEMP"
+
+# Identify the extracted folder (there should be exactly one)
+EXTRACTED_DIR_NAME=$(ls -1 "$EXTRACT_TEMP" | head -n 1)
+
+if [[ -z "$EXTRACTED_DIR_NAME" ]]; then
+    echo -e "${RED}Error: Archive extraction failed or archive is empty.${NC}" >&2
+    exit 1
+fi
+
+echo -e "${BLUE}Detected package folder: $EXTRACTED_DIR_NAME${NC}"
+
+# Move the extracted content to the final destination
+escalate_cmd mv "$EXTRACT_TEMP/$EXTRACTED_DIR_NAME" "$TARGET_APP_DIR"
 
 # Verify execution capability
 if [[ ! -f "$TARGET_APP_DIR/antigravity" ]]; then
-    echo -e "${RED}Error: Extraction completed but executable was not found at $TARGET_APP_DIR/antigravity${NC}" >&2
+    echo -e "${RED}Error: Executable not found at $TARGET_APP_DIR/antigravity${NC}" >&2
+    echo -e "${YELLOW}Contents of $TARGET_APP_DIR:${NC}"
+    escalate_cmd ls -F "$TARGET_APP_DIR"
     exit 1
 fi
 escalate_cmd chmod +x "$TARGET_APP_DIR/antigravity"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -15,11 +15,11 @@ NC='\033[0m' # No Color
 echo -e "${BLUE}=== Antigravity Uninstaller ===${NC}"
 
 # Define target paths
-SYSTEM_OPT_DIR="/opt/Antigravity-x64"
+SYSTEM_OPT_DIR="/opt/Antigravity-Linux"
 SYSTEM_BIN_LINK="/usr/local/bin/antigravity"
 SYSTEM_DESKTOP_DIR="/usr/share/applications"
 
-USER_SHARE_DIR="$HOME/.local/share/Antigravity-x64"
+USER_SHARE_DIR="$HOME/.local/share/Antigravity-Linux"
 USER_BIN_DIR="$HOME/.local/bin"
 USER_DESKTOP_DIR="$HOME/.local/share/applications"
 


### PR DESCRIPTION
This PR adds support for ARM64 (aarch64) architecture and makes the extraction process more robust by automatically detecting the internal folder name in the tarball.

### Changes:
- **install.sh**: Updated pre-flight check to allow `aarch64`. Added logic to detect the extracted directory name dynamically.
- **uninstall.sh**: Updated paths to use the new architecture-agnostic `/opt/Antigravity-Linux` directory.
- **README.md**: Updated documentation to reflect ARM64 support and generic directory naming.

These changes ensure the installer works seamlessly on both standard x86_64 PCs and ARM-based devices (like ARM64 Fedora VMs or laptops).