### PR TITLE
Add IDE/Agent mode and interactive install/uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,11 @@
 #   ./install.sh [options]
 #
 # Options:
-#   --user        Install to user space (~/.local) without requiring root privileges.
-#   --url <url>   Override the default download URL.
-#   --dry-run     Run pre-flight checks and download the package but do not write any files.
-#   -h, --help    Show help message.
+#   --mode <ide|agent> Choose target application variant.
+#   --user             Install to user space (~/.local) without requiring root privileges.
+#   --url <url>        Override the default download URL.
+#   --dry-run          Run pre-flight checks and download the package but do not write any files.
+#   -h, --help         Show help message.
 
 set -euo pipefail
 
@@ -24,10 +25,15 @@ NC='\033[0m' # No Color
 
 # Default values
 INSTALL_SCOPE="system"
-DOWNLOAD_URL="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.0-6324554176528384/linux-x64/Antigravity.tar.gz"
+APP_MODE="" # Starts empty to force interaction if not provided
+
+DOWNLOAD_URL_IDE="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.3-6242596486512640/linux-x64/Antigravity%20IDE.tar.gz"
+DOWNLOAD_URL_AGENT="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.6-5413878570549248/linux-x64/Antigravity.tar.gz"
+
 DRY_RUN=false
 TEMP_DIR=""
 LEGACY_REPOSITIONED=false
+DOWNLOAD_URL=""
 
 # Print usage instructions
 show_help() {
@@ -35,16 +41,26 @@ show_help() {
 Usage: $(basename "$0") [options]
 
 Options:
-  --user        Install to user space (~/.local) without requiring root privileges.
-  --url <url>   Override the default download URL.
-  --dry-run     Perform pre-flight checks and package download only. No files written.
-  -h, --help    Show this help message.
+  --mode <ide|agent> Choose target application variant.
+  --user             Install to user space (~/.local) without requiring root privileges.
+  --url <url>        Override the default download URL.
+  --dry-run          Perform pre-flight checks and package download only. No files written.
+  -h, --help         Show this help message.
 EOF
 }
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --mode)
+            if [[ -n "${2:-}" && ( "$2" == "ide" || "$2" == "agent" ) ]]; then
+                APP_MODE="$2"
+                shift 2
+            else
+                echo -e "${RED}Error: --mode requires a value: 'ide' or 'agent'.${NC}" >&2
+                exit 1
+            fi
+            ;;
         --user)
             INSTALL_SCOPE="user"
             shift
@@ -66,32 +82,72 @@ while [[ $# -gt 0 ]]; do
             show_help
             exit 0
             ;;
-            *)
+        *)
             echo -e "${RED}Error: Unknown option '$1'${NC}" >&2
             show_help
             exit 1
             ;;
-    esac
+        esac
 done
 
 echo -e "${BLUE}${BOLD}=== Antigravity 2.0 Installer ===${NC}"
+
+# --- INTERACTIVE MENU ---
+if [[ -z "$APP_MODE" ]]; then
+    echo -e "\n${BOLD}Select the version you want to install:${NC}"
+    echo -e "  ${GREEN}1)${NC} Antigravity 2.0 ${BOLD}IDE${NC} (Development Environment)"
+    echo -e "  ${GREEN}2)${NC} Antigravity 2.0 ${BOLD}Agent${NC} (Background Agent / Hub)"
+    echo -ne "\nEnter an option [1-2]: "
+
+    read -r OPTION
+
+    case "$OPTION" in
+        1)
+            APP_MODE="ide"
+            ;;
+        2)
+            APP_MODE="agent"
+            ;;
+        *)
+            echo -e "${RED}Invalid option. Canceling installation.${NC}" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+# Define dynamic variables based on selected mode
+if [[ "$APP_MODE" == "ide" ]]; then
+    APP_NAME_SHORT="antigravity-ide"
+    APP_NAME_PRETTY="Antigravity 2.0 IDE"
+    APP_COMMENT="Experience liftoff (v2.0 Standalone IDE)"
+    BINARY_NAME="antigravity-ide"
+    [[ -z "$DOWNLOAD_URL" ]] && DOWNLOAD_URL="$DOWNLOAD_URL_IDE"
+else
+    APP_NAME_SHORT="antigravity"
+    APP_NAME_PRETTY="Antigravity 2.0 Agent"
+    APP_COMMENT="Experience liftoff (v2.0 Agent)"
+    BINARY_NAME="antigravity"
+    [[ -z "$DOWNLOAD_URL" ]] && DOWNLOAD_URL="$DOWNLOAD_URL_AGENT"
+fi
+
+echo -e "\n${BLUE}Selected variant: ${BOLD}${APP_NAME_PRETTY}${NC}"
 echo -e "${BLUE}Targeting scope: ${BOLD}${INSTALL_SCOPE}${NC}"
 
-# Define paths based on install scope
+# Define paths based on install scope and dynamic name
 if [[ "$INSTALL_SCOPE" == "system" ]]; then
     TARGET_PARENT_DIR="/opt"
-    TARGET_APP_DIR="/opt/Antigravity-Linux"
-    TARGET_BIN_PATH="/usr/local/bin/antigravity"
+    TARGET_APP_DIR="/opt/${APP_NAME_SHORT}-Linux"
+    TARGET_BIN_PATH="/usr/local/bin/${APP_NAME_SHORT}"
     DESKTOP_ENTRY_DIR="/usr/share/applications"
-    DESKTOP_ENTRY_PATH="$DESKTOP_ENTRY_DIR/antigravity.desktop"
-    ICON_LOOKUP_NAME="antigravity"
+    DESKTOP_ENTRY_PATH="${DESKTOP_ENTRY_DIR}/${APP_NAME_SHORT}.desktop"
+    ICON_LOOKUP_NAME="antigravity" # Force native asset resource name for desktop styling
 else
     TARGET_PARENT_DIR="$HOME/.local/share"
-    TARGET_APP_DIR="$HOME/.local/share/Antigravity-Linux"
-    TARGET_BIN_PATH="$HOME/.local/bin/antigravity"
+    TARGET_APP_DIR="$HOME/.local/share/${APP_NAME_SHORT}-Linux"
+    TARGET_BIN_PATH="$HOME/.local/bin/${APP_NAME_SHORT}"
     DESKTOP_ENTRY_DIR="$HOME/.local/share/applications"
-    DESKTOP_ENTRY_PATH="$DESKTOP_ENTRY_DIR/antigravity.desktop"
-    ICON_LOOKUP_NAME="antigravity"
+    DESKTOP_ENTRY_PATH="${DESKTOP_ENTRY_DIR}/${APP_NAME_SHORT}.desktop"
+    ICON_LOOKUP_NAME="antigravity" # Force native asset resource name for desktop styling
 fi
 
 # Pre-flight check: CPU Architecture
@@ -125,7 +181,7 @@ TEMP_DIR=$(mktemp -d -t antigravity-install-XXXXXX)
 TEMP_ARCHIVE="$TEMP_DIR/Antigravity.tar.gz"
 
 # Fetch/Download the tarball package
-echo -e "${YELLOW}Downloading Antigravity package...${NC}"
+echo -e "${YELLOW}Downloading ${APP_NAME_PRETTY} package...${NC}"
 if [[ "$DRY_RUN" == "true" ]]; then
     echo -e "${BLUE}[DRY RUN] Would download from: $DOWNLOAD_URL${NC}"
 fi
@@ -189,12 +245,12 @@ echo -e "${BLUE}Detected package folder: $EXTRACTED_DIR_NAME${NC}"
 # Move the extracted content to the final destination
 escalate_cmd mv "$EXTRACT_TEMP/$EXTRACTED_DIR_NAME" "$TARGET_APP_DIR"
 
-# Verify execution capability
-if [[ ! -f "$TARGET_APP_DIR/antigravity" ]]; then
-    echo -e "${RED}Error: Extraction completed but executable was not found at $TARGET_APP_DIR/antigravity${NC}" >&2
+# Verify execution capability using dynamic binary name
+if [[ ! -f "$TARGET_APP_DIR/$BINARY_NAME" ]]; then
+    echo -e "${RED}Error: Extraction completed but executable was not found at $TARGET_APP_DIR/$BINARY_NAME${NC}" >&2
     exit 1
 fi
-escalate_cmd chmod +x "$TARGET_APP_DIR/antigravity"
+escalate_cmd chmod +x "$TARGET_APP_DIR/$BINARY_NAME"
 
 # Configure symlink path
 echo -e "${YELLOW}Configuring system command shortcuts...${NC}"
@@ -204,7 +260,7 @@ if [[ "$INSTALL_SCOPE" == "user" ]]; then
 fi
 
 escalate_cmd rm -f "$TARGET_BIN_PATH"
-escalate_cmd ln -s "$TARGET_APP_DIR/antigravity" "$TARGET_BIN_PATH"
+escalate_cmd ln -s "$TARGET_APP_DIR/$BINARY_NAME" "$TARGET_BIN_PATH"
 
 # Configure Desktop application launcher entry
 echo -e "${YELLOW}Generating Desktop integration entry...${NC}"
@@ -214,25 +270,25 @@ echo -e "${YELLOW}Generating Desktop integration entry...${NC}"
 # -----------------------------------------------------------------------------
 echo -e "${YELLOW}Analyzing system for dual-version coexistence...${NC}"
 
-SYSTEM_DESKTOP_FILE="/usr/share/applications/antigravity.desktop"
-LOCAL_DESKTOP_FILE="$HOME/.local/share/applications/antigravity.desktop"
+SYSTEM_DESKTOP_FILE="/usr/share/applications/${APP_NAME_SHORT}.desktop"
+LOCAL_DESKTOP_FILE="$HOME/.local/share/applications/${APP_NAME_SHORT}.desktop"
 
 if [[ "$INSTALL_SCOPE" == "system" ]]; then
     # 1. System Scope: Check if local desktop file exists and shadows system scope
     if [[ -f "$LOCAL_DESKTOP_FILE" ]]; then
         if grep -q "/usr/share/antigravity" "$LOCAL_DESKTOP_FILE" 2>/dev/null; then
             echo -e "${BLUE}Detected legacy v1.x launcher at user level. Renaming to preserve...${NC}"
-            mv "$LOCAL_DESKTOP_FILE" "$HOME/.local/share/applications/antigravity-legacy.desktop"
+            mv "$LOCAL_DESKTOP_FILE" "$HOME/.local/share/applications/${APP_NAME_SHORT}-legacy.desktop"
             update-desktop-database "$HOME/.local/share/applications" || true
             LEGACY_REPOSITIONED=true
         fi
     fi
-    
+
     # 2. System Scope: Check if system-wide desktop file belongs to v1.x before overwriting
     if [[ -f "$SYSTEM_DESKTOP_FILE" ]]; then
         if grep -q "/usr/share/antigravity" "$SYSTEM_DESKTOP_FILE" 2>/dev/null; then
             echo -e "${BLUE}Detected system-wide legacy v1.x launcher. Renaming to preserve...${NC}"
-            escalate_cmd mv "$SYSTEM_DESKTOP_FILE" "/usr/share/applications/antigravity-legacy.desktop"
+            escalate_cmd mv "$SYSTEM_DESKTOP_FILE" "/usr/share/applications/${APP_NAME_SHORT}-legacy.desktop"
             LEGACY_REPOSITIONED=true
         fi
     fi
@@ -242,16 +298,16 @@ else
     if [[ -f "$LOCAL_DESKTOP_FILE" ]]; then
         if grep -q "/usr/share/antigravity" "$LOCAL_DESKTOP_FILE" 2>/dev/null; then
             echo -e "${BLUE}Detected legacy v1.x launcher at user level. Renaming to preserve...${NC}"
-            mv "$LOCAL_DESKTOP_FILE" "$HOME/.local/share/applications/antigravity-legacy.desktop"
+            mv "$LOCAL_DESKTOP_FILE" "$HOME/.local/share/applications/${APP_NAME_SHORT}-legacy.desktop"
             LEGACY_REPOSITIONED=true
         fi
     fi
-    
+
     # 4. User Scope: Check if system-wide desktop file belongs to v1.x and will be shadowed
     if [[ -f "$SYSTEM_DESKTOP_FILE" ]]; then
         if grep -q "/usr/share/antigravity" "$SYSTEM_DESKTOP_FILE" 2>/dev/null; then
             # Copy system v1.x launcher to user applications folder as legacy to prevent it being shadowed
-            LOCAL_LEGACY_PATH="$HOME/.local/share/applications/antigravity-legacy.desktop"
+            LOCAL_LEGACY_PATH="$HOME/.local/share/applications/${APP_NAME_SHORT}-legacy.desktop"
             if [[ ! -f "$LOCAL_LEGACY_PATH" ]]; then
                 echo -e "${BLUE}Detected system-wide legacy v1.x launcher. Copying to user-space to preserve...${NC}"
                 mkdir -p "$(dirname "$LOCAL_LEGACY_PATH")"
@@ -262,11 +318,11 @@ else
     fi
 fi
 # Clean up older, duplicate desktop launchers to prevent duplicate launcher shortcuts
-escalate_cmd rm -f "$DESKTOP_ENTRY_DIR/antigravity-2.desktop"
+escalate_cmd rm -f "$DESKTOP_ENTRY_DIR/${APP_NAME_SHORT}-2.desktop"
 
 # Generate the desktop integration template dynamically in the secure temp directory
-TEMP_DESKTOP="$TEMP_DIR/antigravity.desktop"
-cat << 'EOF' > "$TEMP_DESKTOP"
+TEMP_DESKTOP="$TEMP_DIR/${APP_NAME_SHORT}.desktop"
+cat << EOF > "$TEMP_DESKTOP"
 [Desktop Entry]
 Version=1.0
 Type=Application
@@ -289,8 +345,8 @@ Exec=__EXEC_PATH__ --ozone-platform-hint=wayland --enable-features=WaylandWindow
 Icon=__ICON_PATH__
 EOF
 
-sed -i "s|__NAME__|Antigravity 2.0|g" "$TEMP_DESKTOP"
-sed -i "s|__COMMENT__|Experience liftoff (v2.0 Standalone)|g" "$TEMP_DESKTOP"
+sed -i "s|__NAME__|$APP_NAME_PRETTY|g" "$TEMP_DESKTOP"
+sed -i "s|__COMMENT__|$APP_COMMENT|g" "$TEMP_DESKTOP"
 sed -i "s|__EXEC_PATH__|$TARGET_BIN_PATH|g" "$TEMP_DESKTOP"
 sed -i "s|__ICON_PATH__|$ICON_LOOKUP_NAME|g" "$TEMP_DESKTOP"
 
@@ -309,14 +365,14 @@ fi
 echo -e "${YELLOW}Updating desktop database shortcuts...${NC}"
 escalate_cmd update-desktop-database "$DESKTOP_ENTRY_DIR" || true
 
-echo -e "${GREEN}${BOLD}✓ Antigravity 2.0 successfully installed!${NC}"
-echo -e "You can launch the IDE via:"
-echo -e "  * Terminal command: ${BOLD}antigravity${NC}"
-echo -e "  * Application menu entry: ${BOLD}Antigravity 2.0${NC}"
+echo -e "${GREEN}${BOLD}✓ ${APP_NAME_PRETTY} successfully installed!${NC}"
+echo -e "You can launch the application via:"
+echo -e "  * Terminal command: ${BOLD}${APP_NAME_SHORT}${NC}"
+echo -e "  * Application menu entry: ${BOLD}${APP_NAME_PRETTY}${NC}"
 
 if [[ "$LEGACY_REPOSITIONED" == "true" ]]; then
     echo -e "\n${YELLOW}${BOLD}⚠️  Coexistence Notice:${NC}"
-    echo -e "  A legacy Antigravity 1.x launcher has been renamed or copied to ${BOLD}antigravity-legacy.desktop${NC}."
+    echo -e "  A legacy Antigravity 1.x launcher has been renamed or copied to ${BOLD}${APP_NAME_SHORT}-legacy.desktop${NC}."
     echo -e "  Due to GNOME Shell's launcher grid caching, you may need to **log out and log back in**"
     echo -e "  for both launchers to appear side-by-side in your applications drawer."
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Antigravity 2.0 Fedora Uninstaller
-# Safe, robust, and clean removal utility.
+# Safe, robust, and clean removal utility with interactive menu.
 
 set -euo pipefail
 
@@ -10,17 +10,42 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
+BOLD='\033[1m'
 NC='\033[0m' # No Color
 
-echo -e "${BLUE}=== Antigravity Uninstaller ===${NC}"
+echo -e "${BLUE}${BOLD}=== Antigravity Uninstaller ===${NC}"
+
+# --- INTERACTIVE MENU ---
+echo -e "\n${BOLD}Select what you want to uninstall:${NC}"
+echo -e "  ${GREEN}1)${NC} Uninstall Antigravity 2.0 ${BOLD}IDE${NC} only"
+echo -e "  ${GREEN}2)${NC} Uninstall Antigravity 2.0 ${BOLD}Agent${NC} only"
+echo -e "  ${GREEN}3)${NC} Uninstall ${BOLD}Both${NC} (Complete Cleanup)"
+echo -ne "\nEnter an option [1-3]: "
+
+read -r OPTION
+
+REMOVE_IDE=false
+REMOVE_AGENT=false
+
+case "$OPTION" in
+    1)
+        REMOVE_IDE=true
+        ;;
+    2)
+        REMOVE_AGENT=true
+        ;;
+    3)
+        REMOVE_IDE=true
+        REMOVE_AGENT=true
+        ;;
+    *)
+        echo -e "${RED}Invalid option. Canceling uninstallation.${NC}" >&2
+        exit 1
+        ;;
+esac
 
 # Define target paths
-SYSTEM_OPT_DIR="/opt/Antigravity-Linux"
-SYSTEM_BIN_LINK="/usr/local/bin/antigravity"
 SYSTEM_DESKTOP_DIR="/usr/share/applications"
-
-USER_SHARE_DIR="$HOME/.local/share/Antigravity-Linux"
-USER_BIN_DIR="$HOME/.local/bin"
 USER_DESKTOP_DIR="$HOME/.local/share/applications"
 
 # Function to safely delete files/folders
@@ -38,36 +63,56 @@ safe_remove() {
     fi
 }
 
-# 1. Check System-wide installations
-if [ -d "$SYSTEM_OPT_DIR" ] || [ -d "/opt/Antigravity-x64" ] || [ -f "$SYSTEM_DESKTOP_DIR/antigravity.desktop" ] || [ -L "$SYSTEM_BIN_LINK" ]; then
-    echo -e "${BLUE}Found system-wide installation files. Requesting removal...${NC}"
-    
-    # Safely remove opt dir, symlink, and desktop entries
-    safe_remove "$SYSTEM_OPT_DIR" "true"
+# --- UNINSTALLATION PROCESS ---
+
+# 1. System-wide removal (Requires sudo if components exist)
+if [ "$REMOVE_AGENT" = "true" ]; then
+    echo -e "\n${BLUE}Checking for system-wide Agent components...${NC}"
+    safe_remove "/opt/Antigravity-Linux" "true"
     safe_remove "/opt/Antigravity-x64" "true"
-    safe_remove "$SYSTEM_BIN_LINK" "true"
+    safe_remove "/usr/local/bin/antigravity" "true"
     safe_remove "$SYSTEM_DESKTOP_DIR/antigravity.desktop" "true"
+    safe_remove "$SYSTEM_DESKTOP_DIR/antigravity-legacy.desktop" "true"
     safe_remove "$SYSTEM_DESKTOP_DIR/antigravity-2.desktop" "true"
     safe_remove "$SYSTEM_DESKTOP_DIR/antigravity-url-handler.desktop" "true"
-    
-    echo -e "${YELLOW}Refreshing system-wide desktop database...${NC}"
+fi
+
+if [ "$REMOVE_IDE" = "true" ]; then
+    echo -e "\n${BLUE}Checking for system-wide IDE components...${NC}"
+    safe_remove "/opt/antigravity-ide-Linux" "true"
+    safe_remove "/usr/local/bin/antigravity-ide" "true"
+    safe_remove "$SYSTEM_DESKTOP_DIR/antigravity-ide.desktop" "true"
+    safe_remove "$SYSTEM_DESKTOP_DIR/antigravity-ide-legacy.desktop" "true"
+fi
+
+# Refresh system-wide desktop database if needed
+if [ -d "$SYSTEM_DESKTOP_DIR" ]; then
     sudo update-desktop-database "$SYSTEM_DESKTOP_DIR" || true
 fi
 
-# 2. Check User-local installations
-if [ -d "$USER_SHARE_DIR" ] || [ -d "$HOME/.local/share/Antigravity-x64" ] || [ -f "$USER_DESKTOP_DIR/antigravity.desktop" ] || [ -f "$USER_DESKTOP_DIR/antigravity-2.desktop" ] || [ -f "$USER_BIN_DIR/antigravity" ]; then
-    echo -e "${BLUE}Found user-local installation files. Removing...${NC}"
-    
-    # Safely remove local share, bin link, and desktop entries
-    safe_remove "$USER_SHARE_DIR" "false"
+
+# 2. User-local removal (No sudo required)
+if [ "$REMOVE_AGENT" = "true" ]; then
+    echo -e "\n${BLUE}Checking for user-local Agent components...${NC}"
+    safe_remove "$HOME/.local/share/Antigravity-Linux" "false"
     safe_remove "$HOME/.local/share/Antigravity-x64" "false"
-    safe_remove "$USER_BIN_DIR/antigravity" "false"
+    safe_remove "$HOME/.local/bin/antigravity" "false"
     safe_remove "$USER_DESKTOP_DIR/antigravity.desktop" "false"
-    safe_remove "$USER_DESKTOP_DIR/antigravity-2.desktop" "false"
     safe_remove "$USER_DESKTOP_DIR/antigravity-legacy.desktop" "false"
-    
-    echo -e "${YELLOW}Refreshing user desktop database...${NC}"
+    safe_remove "$USER_DESKTOP_DIR/antigravity-2.desktop" "false"
+fi
+
+if [ "$REMOVE_IDE" = "true" ]; then
+    echo -e "\n${BLUE}Checking for user-local IDE components...${NC}"
+    safe_remove "$HOME/.local/share/antigravity-ide-Linux" "false"
+    safe_remove "$HOME/.local/bin/antigravity-ide" "false"
+    safe_remove "$USER_DESKTOP_DIR/antigravity-ide.desktop" "false"
+    safe_remove "$USER_DESKTOP_DIR/antigravity-ide-legacy.desktop" "false"
+fi
+
+# Refresh user desktop database if needed
+if [ -d "$USER_DESKTOP_DIR" ]; then
     update-desktop-database "$USER_DESKTOP_DIR" || true
 fi
 
-echo -e "${GREEN}✓ Uninstallation complete. Antigravity has been cleanly removed.${NC}"
+echo -e "\n${GREEN}${BOLD}✓ Uninstallation task completed successfully!${NC}"


### PR DESCRIPTION
Summary
Introduced interactive variant selection for both the installation and uninstallation suites, enabling native support for both Antigravity IDE and Antigravity Agent to be managed independently or coexist side-by-side.

Key Changes
📥 Installer (install.sh)
Interactive Menu & --mode Flag: Added a runtime prompt to choose between ide and agent, with a --mode <ide|agent> CLI bypass for automation.

Dynamic Parameterization: Abstracted paths, download URLs, executable checks, and directory paths using variant-specific variables ($BINARY_NAME, $APP_NAME_SHORT).

Isolated Desktop Entries: Switched to per-variant .desktop generation to prevent launcher conflicts and upgraded legacy v1.x fallback detection.

🗑️ Uninstaller (uninstall.sh)
Selective Removal Menu: Added an interactive menu allowing users to uninstall the IDE only, the Agent only, or perform a Full Cleanup.

Boolean State Engine: Rewrote deletion routines using decoupled logic gates ($REMOVE_IDE / $REMOVE_AGENT) to safely target exact component artifacts.

Environment Maintenance: Cleans up specific system/user directories and triggers proactive update-desktop-database refreshes.

🔒 Robustness Fixes
Fixed a double-execution bug in escalate_cmd that caused directory removal crashes.

Resolved a shell interpreter warning by fixing cat << EOF string boundary definitions.