### PR TITLE
feat: update Antigravity Agent to version 2.1.4 with new download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The output RPM files will be generated in `~/rpkg/` (or the folder defined by `$
 Install the compiled RPMs via `dnf`:
 ```bash
 # Install the Antigravity Agent
-sudo dnf install ~/rpkg/$(uname -m)/antigravity2-2.0.11-*.rpm
+sudo dnf install ~/rpkg/$(uname -m)/antigravity2-2.1.4-*.rpm
 
 # Install the Antigravity IDE
 sudo dnf install ~/rpkg/$(uname -m)/antigravity2-ide-2.0.4-*.rpm

--- a/antigravity2.spec
+++ b/antigravity2.spec
@@ -9,7 +9,7 @@
 
 
 Name:           antigravity2
-Version:        2.0.11
+Version:        2.1.4
 Release:        1%{?dist}
 Summary:        Antigravity 2.0 Agent
 
@@ -17,8 +17,8 @@ License:        Proprietary (Google Terms of Service)
 URL:            https://storage.googleapis.com/antigravity-public/antigravity-hub/index.html
 ExclusiveArch:  x86_64 aarch64
 
-Source0:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.11-6560309696135168/linux-x64/Antigravity.tar.gz
-Source1:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.11-6560309696135168/linux-arm/Antigravity.tar.gz
+Source0:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.1.4-6481382726303744/linux-x64/Antigravity.tar.gz
+Source1:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.1.4-6481382726303744/linux-arm/Antigravity.tar.gz
 Source2:        antigravity2.desktop
 Source3:        antigravity.png
 
@@ -83,6 +83,9 @@ install -m 644 %{SOURCE3} %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%{n
 %{_datadir}/icons/hicolor/512x512/apps/%{name}.png
 
 %changelog
+* Sun Jun 21 2026 Roberto Garcia <jrobertogarcia16@gmail.com> - 2.1.4-1
+- Update to version 2.1.4 with new GCS download URLs
+
 * Thu Jun 04 2026 Roberto Garcia <jrobertogarcia16@gmail.com> - 2.0.11-1
 - Update to version 2.0.11 with new GCS download URLs
 

--- a/install.sh
+++ b/install.sh
@@ -28,13 +28,13 @@ INSTALL_SCOPE="system"
 APP_MODE="" # Starts empty to force interaction if not provided
 
 VERSION_IDE="2.0.4"
-VERSION_AGENT="2.0.11"
+VERSION_AGENT="2.1.4"
 APP_VERSION=""
 
 DOWNLOAD_URL_IDE_X64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.4-6381998290370560/linux-x64/Antigravity%20IDE.tar.gz"
 DOWNLOAD_URL_IDE_ARM64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.0.4-6381998290370560/linux-arm/Antigravity%20IDE.tar.gz"
-DOWNLOAD_URL_AGENT_X64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.11-6560309696135168/linux-x64/Antigravity.tar.gz"
-DOWNLOAD_URL_AGENT_ARM64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.11-6560309696135168/linux-arm/Antigravity.tar.gz"
+DOWNLOAD_URL_AGENT_X64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.1.4-6481382726303744/linux-x64/Antigravity.tar.gz"
+DOWNLOAD_URL_AGENT_ARM64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.1.4-6481382726303744/linux-arm/Antigravity.tar.gz"
 DOWNLOAD_URL_IDE=""
 DOWNLOAD_URL_AGENT=""
 


### PR DESCRIPTION
Update Antigravity Agent URLs for both x64 and ARM64 with version 2.1.4