### PR TITLE
Updated Antigravity2 and IDE to 2.8.1 and 2.5.5

### DIFF
--- a/antigravity2-ide.spec
+++ b/antigravity2-ide.spec
@@ -9,7 +9,7 @@
 
 
 Name:           antigravity2-ide
-Version:        2.1.1
+Version:        2.5.5
 Release:        1%{?dist}
 Summary:        Antigravity 2.0 IDE
 
@@ -17,8 +17,8 @@ License:        Proprietary (Google Terms of Service)
 URL:            https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/index.html
 ExclusiveArch:  x86_64 aarch64
 
-Source0:        https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.1.1-6123990880747520/linux-x64/Antigravity%20IDE.tar.gz
-Source1:        https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.1.1-6123990880747520/linux-arm/Antigravity%20IDE.tar.gz
+Source0:        https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-x64/Antigravity%20IDE.tar.gz
+Source1:        https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-arm/Antigravity%20IDE.tar.gz
 Source2:        antigravity2-ide.desktop
 Source3:        antigravity.png
 
@@ -82,7 +82,10 @@ install -m 644 %{SOURCE3} %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%{n
 %{_datadir}/icons/hicolor/512x512/apps/%{name}.png
 
 %changelog
-* Wed Jun 25 2026 Roberto Garcia <jrobertogarcia16@gmail.com> - 2.1.1-1
+* Fri Aug 14 2026 Rajeev RK <rajeevrk@xlncenterprises.com> - 2.5.5-1
+- Update IDE to version 2.5.5 with new download URLs
+
+* Thu Jun 25 2026 Roberto Garcia <jrobertogarcia16@gmail.com> - 2.1.1-1
 - Update to version 2.1.1 with new download URLs and native ARM64 support
 
 * Thu Jun 04 2026 Roberto Garcia <jrobertogarcia16@gmail.com> - 2.0.4-1

--- a/antigravity2.spec
+++ b/antigravity2.spec
@@ -9,7 +9,7 @@
 
 
 Name:           antigravity2
-Version:        2.4.2
+Version:        2.8.1
 Release:        1%{?dist}
 Summary:        Antigravity 2.0 Agent
 
@@ -17,8 +17,8 @@ License:        Proprietary (Google Terms of Service)
 URL:            https://storage.googleapis.com/antigravity-public/antigravity-hub/index.html
 ExclusiveArch:  x86_64 aarch64
 
-Source0:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.4.2-6711062033203200/linux-x64/Antigravity.tar.gz
-Source1:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.4.2-6711062033203200/linux-arm/Antigravity.tar.gz
+Source0:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/linux-x64/Antigravity.tar.gz 
+Source1:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/linux-arm/Antigravity.tar.gz
 Source2:        antigravity2.desktop
 Source3:        antigravity.png
 
@@ -83,6 +83,9 @@ install -m 644 %{SOURCE3} %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%{n
 %{_datadir}/icons/hicolor/512x512/apps/%{name}.png
 
 %changelog
+* Fri Aug  14 2026 Rajeev RK <rajeevrk@xlncenterprises.com> - 2.8.1-1
+- Update to version 2.8.1 with new GCS download URLs
+
 * Sun Jul 26 2026 Roberto Garcia <jrobertogarcia16@gmail.com> - 2.4.2-1
 - Update to version 2.4.2 with new GCS download URLs
 

--- a/install.sh
+++ b/install.sh
@@ -27,14 +27,14 @@ NC='\033[0m' # No Color
 INSTALL_SCOPE="system"
 APP_MODE="" # Starts empty to force interaction if not provided
 
-VERSION_IDE="2.1.1"
-VERSION_AGENT="2.4.2"
+VERSION_IDE="2.5.5"
+VERSION_AGENT="2.8.1"
 APP_VERSION=""
 
-DOWNLOAD_URL_IDE_X64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.1.1-6123990880747520/linux-x64/Antigravity%20IDE.tar.gz"
-DOWNLOAD_URL_IDE_ARM64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.1.1-6123990880747520/linux-arm/Antigravity%20IDE.tar.gz"
-DOWNLOAD_URL_AGENT_X64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.4.2-6711062033203200/linux-x64/Antigravity.tar.gz"
-DOWNLOAD_URL_AGENT_ARM64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.4.2-6711062033203200/linux-arm/Antigravity.tar.gz"
+DOWNLOAD_URL_IDE_X64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-x64/Antigravity%20IDE.tar.gz"
+DOWNLOAD_URL_IDE_ARM64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-arm/Antigravity%20IDE.tar.gz"
+DOWNLOAD_URL_AGENT_X64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/linux-x64/Antigravity.tar.gz"
+DOWNLOAD_URL_AGENT_ARM64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/linux-arm/Antigravity.tar.gz"
 DOWNLOAD_URL_IDE=""
 DOWNLOAD_URL_AGENT=""
 


### PR DESCRIPTION
Updated Antigravity2 and Antigravity2-IDE Versions to 2.8.1 and 2.5.5 respectively. RajeevRK