### PR TITLE
feat: update Antigravity Agent to 2.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The output RPM files will be generated in `~/rpkg/` (or the folder defined by `$
 Install the compiled RPMs via `dnf`:
 ```bash
 # Install the Antigravity Agent
-sudo dnf install ~/rpkg/$(uname -m)/antigravity2-2.9.1-*.rpm
+sudo dnf install ~/rpkg/$(uname -m)/antigravity2-2.11.0-*.rpm
 
 # Install the Antigravity IDE
 sudo dnf install ~/rpkg/$(uname -m)/antigravity2-ide-2.5.5-*.rpm

--- a/antigravity2.spec
+++ b/antigravity2.spec
@@ -9,7 +9,7 @@
 
 
 Name:           antigravity2
-Version:        2.9.1
+Version:        2.11.0
 Release:        1%{?dist}
 Summary:        Antigravity 2.0 Agent
 
@@ -17,8 +17,8 @@ License:        Proprietary (Google Terms of Service)
 URL:            https://storage.googleapis.com/antigravity-public/antigravity-hub/index.html
 ExclusiveArch:  x86_64 aarch64
 
-Source0:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.9.1-4871453687021568/linux-x64/Antigravity.tar.gz#/Antigravity-x64.tar.gz
-Source1:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.9.1-4871453687021568/linux-arm/Antigravity.tar.gz#/Antigravity-arm64.tar.gz
+Source0:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/linux-x64/Antigravity.tar.gz#/Antigravity-x64.tar.gz
+Source1:        https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/linux-arm/Antigravity.tar.gz#/Antigravity-arm64.tar.gz
 Source2:        antigravity2.desktop
 Source3:        antigravity.png
 
@@ -83,6 +83,9 @@ install -m 644 %{SOURCE3} %{buildroot}%{_datadir}/icons/hicolor/512x512/apps/%{n
 %{_datadir}/icons/hicolor/512x512/apps/%{name}.png
 
 %changelog
+* Sat Aug 29 2026 Roberto Garcia <jrobertogarcia16@gmail.com> - 2.11.0-1
+- Update to version 2.11.0 with new GCS download URLs
+
 * Sat Aug 22 2026 pjv <ezelspinguin@gmail.com> - 2.9.1-1
 - Update to version 2.9.1 with new GCS download URLs
 

--- a/install.sh
+++ b/install.sh
@@ -28,13 +28,13 @@ INSTALL_SCOPE="system"
 APP_MODE="" # Starts empty to force interaction if not provided
 
 VERSION_IDE="2.5.5"
-VERSION_AGENT="2.9.1"
+VERSION_AGENT="2.11.0"
 APP_VERSION=""
 
 DOWNLOAD_URL_IDE_X64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-x64/Antigravity%20IDE.tar.gz"
 DOWNLOAD_URL_IDE_ARM64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-arm/Antigravity%20IDE.tar.gz"
-DOWNLOAD_URL_AGENT_X64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.9.1-4871453687021568/linux-x64/Antigravity.tar.gz"
-DOWNLOAD_URL_AGENT_ARM64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.9.1-4871453687021568/linux-arm/Antigravity.tar.gz"
+DOWNLOAD_URL_AGENT_X64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/linux-x64/Antigravity.tar.gz"
+DOWNLOAD_URL_AGENT_ARM64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/linux-arm/Antigravity.tar.gz"
 DOWNLOAD_URL_IDE=""
 DOWNLOAD_URL_AGENT=""
 


### PR DESCRIPTION
## Why
Update the Antigravity 2.0 Agent to version 2.11.0 to pull the latest upstream Google release binaries for x86_64 and ARM64.

## What
- Update `VERSION_AGENT` and upstream download URLs in `install.sh`.
- Bump spec version to `2.11.0`, update source archive URLs, and add a changelog entry in `antigravity2.spec`.
- Update the RPM installation command example in `README.md`.

## Tested
- Verified pre-flight checks, URL accessibility, and tarball downloads using `./install.sh --dry-run --mode agent`.
