### PR TITLE
refactor: simplify branding to Antigravity 2.0 and Antigravity IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Antigravity 2.0 Fedora Installer
 
-Native installation and packaging utility for running **Antigravity 2.0 Agent** and **Antigravity 2.0 IDE** on Fedora Workstation.
+Native installation and packaging utility for running **Antigravity 2.0** and **Antigravity IDE** on Fedora Workstation.
 
 This project supports installation via direct scripts (`install.sh`) or native Fedora RPM packages built locally.
 
@@ -25,13 +25,13 @@ Clone the repository and run the script:
 ```
 
 Unless `--mode` is specified, the installer runs interactively and prompts you to select the target variant:
-1. **Antigravity 2.0 IDE** (Development Environment)
-2. **Antigravity 2.0 Agent** (Background Agent / Hub)
+1. **Antigravity IDE**
+2. **Antigravity 2.0** (Desktop App)
 
 ### Command-Line Arguments
 | Option | Argument | Description |
 | :--- | :--- | :--- |
-| `--mode` | `ide` \| `agent` | Choose the target variant to install (bypasses interactive menu). |
+| `--mode` | `ide` \| `app` | Choose the target variant to install (bypasses interactive menu). |
 | `--user` | *None* | Install to user space (`~/.local`) without requiring root/sudo. |
 | `--url` | `<url>` | Override the default download URL. |
 | `--dry-run` | *None* | Perform validation checks and download the package without writing files. |
@@ -66,11 +66,11 @@ sudo dnf install -y spectool rpkg tar gzip
 
 ### 2. Build the RPMs
 Run the corresponding build script to download the upstream archives and package them locally:
-*   **Build Agent RPM (`antigravity2`)**:
+*   **Build Antigravity 2.0 RPM (`antigravity2`)**:
     ```bash
     ./build.sh
     ```
-*   **Build IDE RPM (`antigravity2-ide`)**:
+*   **Build Antigravity IDE RPM (`antigravity2-ide`)**:
     ```bash
     ./build-ide.sh
     ```
@@ -79,10 +79,10 @@ The output RPM files will be generated in `~/rpkg/` (or the folder defined by `$
 ### 3. Install the RPMs
 Install the compiled RPMs via `dnf`:
 ```bash
-# Install the Antigravity Agent
+# Install Antigravity 2.0
 sudo dnf install ~/rpkg/$(uname -m)/antigravity2-2.11.0-*.rpm
 
-# Install the Antigravity IDE
+# Install Antigravity IDE
 sudo dnf install ~/rpkg/$(uname -m)/antigravity2-ide-2.5.5-*.rpm
 ```
 
@@ -94,8 +94,8 @@ The CLI command name depends on your chosen installation method:
 
 | Application | Installed via Script (`install.sh`) | Installed via RPM |
 | :--- | :--- | :--- |
-| **Antigravity 2.0 Agent** | `antigravity` | `antigravity2` |
-| **Antigravity 2.0 IDE** | `antigravity-ide` | `antigravity2-ide` |
+| **Antigravity 2.0** | `antigravity` | `antigravity2` |
+| **Antigravity IDE** | `antigravity-ide` | `antigravity2-ide` |
 
 ### Wayland & Performance Optimizations
 The generated desktop entries run Chromium/Electron using native Wayland flags for accelerated hardware rendering:
@@ -115,7 +115,7 @@ Use the [uninstall.sh](uninstall.sh) utility to cleanly remove all files, direct
 ```bash
 ./uninstall.sh [options]
 ```
-*   **CLI Options**: `--ide` (IDE only), `--agent` (Agent only), `--both` (complete cleanup), or `--user` (limit scope to user space).
+*   **CLI Options**: `--ide` (IDE only), `--app` (Antigravity 2.0 only), `--both` (complete cleanup), or `--user` (limit scope to user space).
 *   **Interactive Menu**: Run `./uninstall.sh` without options to choose via terminal prompt.
 
 #### RPM-Based Uninstallation

--- a/antigravity2-ide.desktop
+++ b/antigravity2-ide.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=Antigravity 2.0 IDE
+Name=Antigravity IDE
 Comment=Experience liftoff (IDE)
 GenericName=Text Editor
 Exec=/usr/bin/antigravity2-ide --ozone-platform-hint=wayland --enable-features=WaylandWindowDecorations,CanvasOopRasterization --enable-gpu-rasterization --enable-zero-copy %F

--- a/antigravity2-ide.spec
+++ b/antigravity2-ide.spec
@@ -11,7 +11,7 @@
 Name:           antigravity2-ide
 Version:        2.5.5
 Release:        1%{?dist}
-Summary:        Antigravity 2.0 IDE
+Summary:        Antigravity IDE
 
 License:        Proprietary (Google Terms of Service)
 URL:            https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/index.html
@@ -26,8 +26,8 @@ BuildRequires:  tar
 BuildRequires:  gzip
 
 %description
-Antigravity 2.0 IDE repackaged for Fedora.
-Experience liftoff (v2.0 Standalone IDE).
+Antigravity IDE standalone development environment repackaged for Fedora.
+Experience liftoff (IDE).
 
 %prep
 %setup -c -T

--- a/antigravity2.spec
+++ b/antigravity2.spec
@@ -11,7 +11,7 @@
 Name:           antigravity2
 Version:        2.11.0
 Release:        1%{?dist}
-Summary:        Antigravity 2.0 Agent
+Summary:        Antigravity 2.0 Desktop Application
 
 License:        Proprietary (Google Terms of Service)
 URL:            https://storage.googleapis.com/antigravity-public/antigravity-hub/index.html
@@ -26,8 +26,8 @@ BuildRequires:  tar
 BuildRequires:  gzip
 
 %description
-Antigravity 2.0 Agent (Background Agent / Hub) repackaged for Fedora.
-Experience liftoff (v2.0 Agent).
+Antigravity 2.0 desktop application repackaged for Fedora.
+Experience liftoff.
 
 %prep
 %setup -c -T

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #   ./install.sh [options]
 #
 # Options:
-#   --mode <ide|agent> Choose target application variant.
+#   --mode <ide|app>   Choose target application variant.
 #   --user             Install to user space (~/.local) without requiring root privileges.
 #   --url <url>        Override the default download URL.
 #   --dry-run          Run pre-flight checks and download the package but do not write any files.
@@ -28,15 +28,15 @@ INSTALL_SCOPE="system"
 APP_MODE="" # Starts empty to force interaction if not provided
 
 VERSION_IDE="2.5.5"
-VERSION_AGENT="2.11.0"
+VERSION_APP="2.11.0"
 APP_VERSION=""
 
 DOWNLOAD_URL_IDE_X64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-x64/Antigravity%20IDE.tar.gz"
 DOWNLOAD_URL_IDE_ARM64="https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.5-4923483625488384/linux-arm/Antigravity%20IDE.tar.gz"
-DOWNLOAD_URL_AGENT_X64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/linux-x64/Antigravity.tar.gz"
-DOWNLOAD_URL_AGENT_ARM64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/linux-arm/Antigravity.tar.gz"
+DOWNLOAD_URL_APP_X64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/linux-x64/Antigravity.tar.gz"
+DOWNLOAD_URL_APP_ARM64="https://storage.googleapis.com/antigravity-public/antigravity-hub/2.11.0-6376446768316416/linux-arm/Antigravity.tar.gz"
 DOWNLOAD_URL_IDE=""
-DOWNLOAD_URL_AGENT=""
+DOWNLOAD_URL_APP=""
 
 DRY_RUN=false
 TEMP_DIR=""
@@ -63,7 +63,7 @@ show_help() {
 Usage: $(basename "$0") [options]
 
 Options:
-  --mode <ide|agent> Choose target application variant.
+  --mode <ide|app>   Choose target application variant (options: ide, app).
   --user             Install to user space (~/.local) without requiring root privileges.
   --url <url>        Override the default download URL.
   --dry-run          Perform pre-flight checks and package download only. No files written.
@@ -76,11 +76,15 @@ EOF
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --mode)
-            if [[ -n "${2:-}" && ( "$2" == "ide" || "$2" == "agent" ) ]]; then
-                APP_MODE="$2"
+            if [[ -n "${2:-}" && ( "$2" == "ide" || "$2" == "app" || "$2" == "agent" ) ]]; then
+                if [[ "$2" == "agent" ]]; then
+                    APP_MODE="app"
+                else
+                    APP_MODE="$2"
+                fi
                 shift 2
             else
-                echo -e "${RED}Error: --mode requires a value: 'ide' or 'agent'.${NC}" >&2
+                echo -e "${RED}Error: --mode requires a value: 'ide' or 'app'.${NC}" >&2
                 exit 1
             fi
             ;;
@@ -117,17 +121,17 @@ while [[ $# -gt 0 ]]; do
         esac
 done
 
-echo -e "${BLUE}${BOLD}=== Antigravity 2.0 Installer ===${NC}"
+echo -e "${BLUE}${BOLD}=== Antigravity Installer ===${NC}"
 
 # --- INTERACTIVE MENU ---
 if [[ -z "$APP_MODE" ]]; then
     if [[ ! -t 0 ]]; then
-        echo -e "${RED}Error: Standard input is not a terminal. Please specify --mode <ide|agent>.${NC}" >&2
+        echo -e "${RED}Error: Standard input is not a terminal. Please specify --mode <ide|app>.${NC}" >&2
         exit 1
     fi
-    echo -e "\n${BOLD}Select the version you want to install:${NC}"
-    echo -e "  ${GREEN}1)${NC} Antigravity 2.0 ${BOLD}IDE${NC} (Development Environment)"
-    echo -e "  ${GREEN}2)${NC} Antigravity 2.0 ${BOLD}Agent${NC} (Background Agent / Hub)"
+    echo -e "\n${BOLD}Select the application you want to install:${NC}"
+    echo -e "  ${GREEN}1)${NC} ${BOLD}Antigravity IDE${NC}"
+    echo -e "  ${GREEN}2)${NC} ${BOLD}Antigravity 2.0${NC} (Desktop App)"
     echo -ne "\nEnter an option [1-2]: "
 
     read -r OPTION
@@ -137,7 +141,7 @@ if [[ -z "$APP_MODE" ]]; then
             APP_MODE="ide"
             ;;
         2)
-            APP_MODE="agent"
+            APP_MODE="app"
             ;;
         *)
             echo -e "${RED}Invalid option. Canceling installation.${NC}" >&2
@@ -156,27 +160,29 @@ fi
 # Dynamic URL Selection based on architecture
 if [[ "$ARCH" == "aarch64" ]]; then
     DOWNLOAD_URL_IDE="$DOWNLOAD_URL_IDE_ARM64"
-    DOWNLOAD_URL_AGENT="$DOWNLOAD_URL_AGENT_ARM64"
+    DOWNLOAD_URL_APP="$DOWNLOAD_URL_APP_ARM64"
 else
     DOWNLOAD_URL_IDE="$DOWNLOAD_URL_IDE_X64"
-    DOWNLOAD_URL_AGENT="$DOWNLOAD_URL_AGENT_X64"
+    DOWNLOAD_URL_APP="$DOWNLOAD_URL_APP_X64"
 fi
 
 # Define dynamic variables based on selected mode
 if [[ "$APP_MODE" == "ide" ]]; then
     APP_NAME_SHORT="antigravity-ide"
-    APP_NAME_PRETTY="Antigravity 2.0 IDE"
-    APP_COMMENT="Experience liftoff (v2.0 Standalone IDE)"
+    APP_NAME_PRETTY="Antigravity IDE"
+    APP_COMMENT="Experience liftoff (IDE)"
+    APP_WMCLASS="antigravity-ide"
     BINARY_NAME="antigravity-ide"
     APP_VERSION="$VERSION_IDE"
     [[ -z "$DOWNLOAD_URL" ]] && DOWNLOAD_URL="$DOWNLOAD_URL_IDE"
 else
     APP_NAME_SHORT="antigravity"
-    APP_NAME_PRETTY="Antigravity 2.0 Agent"
-    APP_COMMENT="Experience liftoff (v2.0 Agent)"
+    APP_NAME_PRETTY="Antigravity 2.0"
+    APP_COMMENT="Experience liftoff"
+    APP_WMCLASS="Antigravity"
     BINARY_NAME="antigravity"
-    APP_VERSION="$VERSION_AGENT"
-    [[ -z "$DOWNLOAD_URL" ]] && DOWNLOAD_URL="$DOWNLOAD_URL_AGENT"
+    APP_VERSION="$VERSION_APP"
+    [[ -z "$DOWNLOAD_URL" ]] && DOWNLOAD_URL="$DOWNLOAD_URL_APP"
 fi
 
 echo -e "\n${BLUE}Selected variant: ${BOLD}${APP_NAME_PRETTY}${NC}"
@@ -470,7 +476,7 @@ Terminal=false
 Categories=Development;IDE;TextEditor;
 MimeType=application/x-antigravity-workspace;
 StartupNotify=true
-StartupWMClass=Antigravity
+StartupWMClass=__WMCLASS__
 Actions=new-empty-window;
 Keywords=vscode;
 
@@ -484,6 +490,7 @@ sed -i "s|__NAME__|$APP_NAME_PRETTY|g" "$TEMP_DESKTOP"
 sed -i "s|__COMMENT__|$APP_COMMENT|g" "$TEMP_DESKTOP"
 sed -i "s|__EXEC_PATH__|$TARGET_BIN_PATH|g" "$TEMP_DESKTOP"
 sed -i "s|__ICON_PATH__|$ICON_LOOKUP_NAME|g" "$TEMP_DESKTOP"
+sed -i "s|__WMCLASS__|$APP_WMCLASS|g" "$TEMP_DESKTOP"
 
 # Install desktop file to applications folder
 escalate_cmd mkdir -p "$DESKTOP_ENTRY_DIR"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -17,7 +17,7 @@ echo -e "${BLUE}${BOLD}=== Antigravity Uninstaller ===${NC}"
 
 # Default values
 REMOVE_IDE=false
-REMOVE_AGENT=false
+REMOVE_APP=false
 INSTALL_SCOPE="all"
 
 show_help() {
@@ -25,8 +25,8 @@ show_help() {
 Usage: $(basename "$0") [options]
 
 Options:
-  --ide       Uninstall Antigravity 2.0 IDE only.
-  --agent     Uninstall Antigravity 2.0 Agent only.
+  --ide       Uninstall Antigravity IDE only.
+  --app       Uninstall Antigravity 2.0 only.
   --both      Uninstall both variants (complete cleanup).
   --user      Limit scope to user space (~/.local) without requiring root privileges.
   -h, --help  Show this help message.
@@ -40,13 +40,13 @@ while [[ $# -gt 0 ]]; do
             REMOVE_IDE=true
             shift
             ;;
-        --agent)
-            REMOVE_AGENT=true
+        --app|--agent)
+            REMOVE_APP=true
             shift
             ;;
         --both)
             REMOVE_IDE=true
-            REMOVE_AGENT=true
+            REMOVE_APP=true
             shift
             ;;
         --user)
@@ -66,15 +66,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 # --- INTERACTIVE MENU ---
-if [[ "$REMOVE_IDE" == "false" && "$REMOVE_AGENT" == "false" ]]; then
+if [[ "$REMOVE_IDE" == "false" && "$REMOVE_APP" == "false" ]]; then
     if [[ ! -t 0 ]]; then
-        echo -e "${RED}Error: Standard input is not a terminal. Please specify what to remove using --ide, --agent, or --both.${NC}" >&2
+        echo -e "${RED}Error: Standard input is not a terminal. Please specify what to remove using --ide, --app, or --both.${NC}" >&2
         exit 1
     fi
 
     echo -e "\n${BOLD}Select what you want to uninstall:${NC}"
-    echo -e "  ${GREEN}1)${NC} Uninstall Antigravity 2.0 ${BOLD}IDE${NC} only"
-    echo -e "  ${GREEN}2)${NC} Uninstall Antigravity 2.0 ${BOLD}Agent${NC} only"
+    echo -e "  ${GREEN}1)${NC} Uninstall ${BOLD}Antigravity IDE${NC} only"
+    echo -e "  ${GREEN}2)${NC} Uninstall ${BOLD}Antigravity 2.0${NC} only"
     echo -e "  ${GREEN}3)${NC} Uninstall ${BOLD}Both${NC} (Complete Cleanup)"
     echo -ne "\nEnter an option [1-3]: "
 
@@ -85,11 +85,11 @@ if [[ "$REMOVE_IDE" == "false" && "$REMOVE_AGENT" == "false" ]]; then
             REMOVE_IDE=true
             ;;
         2)
-            REMOVE_AGENT=true
+            REMOVE_APP=true
             ;;
         3)
             REMOVE_IDE=true
-            REMOVE_AGENT=true
+            REMOVE_APP=true
             ;;
         *)
             echo -e "${RED}Invalid option. Canceling uninstallation.${NC}" >&2
@@ -121,8 +121,8 @@ safe_remove() {
 
 # 1. System-wide removal (Requires sudo if components exist, only executed if scope is not "user")
 if [ "$INSTALL_SCOPE" != "user" ]; then
-    if [ "$REMOVE_AGENT" = "true" ]; then
-        echo -e "\n${BLUE}Checking for system-wide Agent components...${NC}"
+    if [ "$REMOVE_APP" = "true" ]; then
+        echo -e "\n${BLUE}Checking for system-wide Antigravity 2.0 components...${NC}"
         safe_remove "/opt/antigravity-Linux" "true"
         safe_remove "/opt/Antigravity-Linux" "true"
         safe_remove "/opt/Antigravity-x64" "true"
@@ -134,7 +134,7 @@ if [ "$INSTALL_SCOPE" != "user" ]; then
     fi
 
     if [ "$REMOVE_IDE" = "true" ]; then
-        echo -e "\n${BLUE}Checking for system-wide IDE components...${NC}"
+        echo -e "\n${BLUE}Checking for system-wide Antigravity IDE components...${NC}"
         safe_remove "/opt/antigravity-ide-Linux" "true"
         safe_remove "/usr/local/bin/antigravity-ide" "true"
         safe_remove "$SYSTEM_DESKTOP_DIR/antigravity-ide.desktop" "true"
@@ -149,8 +149,8 @@ fi
 
 
 # 2. User-local removal (No sudo required)
-if [ "$REMOVE_AGENT" = "true" ]; then
-    echo -e "\n${BLUE}Checking for user-local Agent components...${NC}"
+if [ "$REMOVE_APP" = "true" ]; then
+    echo -e "\n${BLUE}Checking for user-local Antigravity 2.0 components...${NC}"
     safe_remove "$HOME/.local/share/antigravity-Linux" "false"
     safe_remove "$HOME/.local/share/Antigravity-Linux" "false"
     safe_remove "$HOME/.local/share/Antigravity-x64" "false"
@@ -161,7 +161,7 @@ if [ "$REMOVE_AGENT" = "true" ]; then
 fi
 
 if [ "$REMOVE_IDE" = "true" ]; then
-    echo -e "\n${BLUE}Checking for user-local IDE components...${NC}"
+    echo -e "\n${BLUE}Checking for user-local Antigravity IDE components...${NC}"
     safe_remove "$HOME/.local/share/antigravity-ide-Linux" "false"
     safe_remove "$HOME/.local/bin/antigravity-ide" "false"
     safe_remove "$USER_DESKTOP_DIR/antigravity-ide.desktop" "false"


### PR DESCRIPTION
## Why
The legacy terms "Antigravity 2.0 Agent" and "Antigravity 2.0 IDE" were redundant and caused confusion regarding the roles of the two applications.

## What
- Rebrand the applications to "Antigravity 2.0" (Desktop App) and "Antigravity IDE" across documentation, spec files, scripts, and desktop launchers.
- Remove all "Agent" references from interactive menus and internal script variables while retaining `--mode agent` and `--agent` as backwards-compatible CLI aliases.
- Add dynamic `StartupWMClass` templating in `install.sh` for proper window grouping.

## Tested
- Validated shell scripts with `bash -n`.
- Validated desktop entry files with `desktop-file-validate`.
- Verified CLI help flags and execution via `./install.sh --mode app --dry-run`.
